### PR TITLE
Add CI for automatic unit tests

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,29 @@
+name: Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.6.8', '3.7', '3.8']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libopenblas-dev libsuitesparse-dev libdsdp-dev libfftw3-dev libglpk-dev libgsl0-dev
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov coveralls wheel tox
+    - name: Test with tox
+      run: |
+        tox


### PR DESCRIPTION
Use tox to run package installation and unit tests.

Close #4

Signed-off-by: Jensen Zhang <jingxuan.n.zhang@gmail.com>