### PR TITLE
Hotfix python version not found issue

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,22 +5,23 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
         python-version: ['3.6.8', '3.7', '3.8']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libopenblas-dev libsuitesparse-dev libdsdp-dev libfftw3-dev libglpk-dev libgsl0-dev
         python -m pip install --upgrade pip
         pip install pytest pytest-cov coveralls wheel tox


### PR DESCRIPTION
Fix the following error raised by github actions:

    Version X was not found in the local cache
    Error: Version X with arch x64 not found

It may be caused by actions/setup-python#555

Consider the users of openalto may still depend on python 3.6, roll back ubuntu version from `ubuntu-latest` to `ubuntu-20.04`.

Signed-off-by: Jensen Zhang <jingxuan.n.zhang@gmail.com>