### PR TITLE
Add providing OpenAPI specification(yaml) for northbound API in code-first manner.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Contributors
 
 * Jensen Zhang <jingxuan.n.zhang@gmail.com>
 * Kai Gao <emiapwil@gmail.com>
+* itaru2622 <itaru2622@gmail.com>

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ install_requires =
     gunicorn
     jsonpatch
     json-merge-patch
+    pyyaml
+    uritemplate
 
 
 [options.packages.find]

--- a/src/alto/server/northbound/alto/urls.py
+++ b/src/alto/server/northbound/alto/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from rest_framework.schemas import get_schema_view
 
 from alto.config import Config
 
@@ -30,6 +31,9 @@ def generate_northbound_routes():
             tips_data_view = views.get_view('tips-data', resource_id, namespace, algorithm, params)
             urlpatterns.append(path('tips/<resource_id>/<digest>/ug/<int:start_seq>/<int:end_seq>',
                                     tips_data_view, name='{}:metadata'.format(resource_id)))
+
+    urlpatterns.append(path('openapi.yaml', get_schema_view(
+        title="openalto/alto northbound API", description="openalto/alto northbound API"), name='openapi-schema'))
     return urlpatterns
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,7 +166,7 @@ class ALTONorthboundTest(TestCase):
         tips_resources = [r for r in resources if resources[r]['type'] == 'tips']
 
         urls = show_urls(get_resolver().url_patterns)
-        assert len(urls) == len(resources) + 1 + len(tips_resources) * 4
+        assert len(urls) == len(resources) + 1 + len(tips_resources) * 4 + 1
 
         for route in TEST_ROUTES:
             perform_route_test(route)


### PR DESCRIPTION
Fix #45

OpenAPI specification is generated from code and can be got by curl -X GET http://alto-frontend:8000/openapi.yaml
This feature is powered by https://www.django-rest-framework.org/api-guide/schemas/#generating-an-openapi-schema