### PR TITLE
Add a thirdparty perfsonar backend proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.10.7
 
 COPY . /tmp/alto
 RUN rm -rf /tmp/alto/.git && \
-    pip install redis geoip2 kazoo && \
-    pip install /tmp/alto && \
+    pip install redis geoip2 kazoo -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip install /tmp/alto -i https://pypi.tuna.tsinghua.edu.cn/simple && \
     rm -rf /tmp/alto
 
 EXPOSE 8000

--- a/etc/alto.conf.test
+++ b/etc/alto.conf.test
@@ -84,6 +84,10 @@ cost_types = {
     "cost-mode": "numerical",
     "cost-metric": "routingcost"
   },
+  "avg-tput": {
+    "cost-mode": "numerical",
+    "cost-metric": "tput:mean"
+  },
   "path-vector": {
     "cost-mode": "array",
     "cost-metric": "ane-path"}}
@@ -149,6 +153,18 @@ resources = {
     },
     "params": {
       "data_source": "geoip"
+    }
+  },
+  "ps": {
+    "type": "endpoint-cost",
+    "path": "endpointcost",
+    "namespace": "default",
+    "algorithm": "alto.server.components.ext.perfsonar.WrappedPerfSonarServiceV1",
+    "capabilities": {
+      "cost-type-names": [ "avg-tput" ]
+    },
+    "params": {
+      "visualnet_api": "http://localhost:8000/endpointcost/lookup"
     }
   },
   "geodist": {

--- a/src/alto/mock.py
+++ b/src/alto/mock.py
@@ -233,6 +233,23 @@ TEST_ECS = {
     }
 }
 
+TEST_VISUALNET_API_ECS = {
+    "meta": {
+        "cost-type": {
+            "cost-metric": "tput:mean",
+            "anchor-alg": "same-site",
+            "interval": {
+                "last": "2d"
+            }
+        }
+    },
+    "endpoint-cost-map": {
+        "ipv4:202.122.33.13": {
+            "ipv4:192.41.231.82": 2031505542.25
+        }
+    }
+}
+
 TEST_ECS_PV = """--d41d8cd98f00b204e9800998ecf8427e
 Content-Type: application/alto-endpointcost+json
 Content-ID: <ecs@localhost>
@@ -403,6 +420,12 @@ MOCK = [
         'uri': 'http://localhost:8181/alto/pathvector/pv',
         'headers': {'content-type': 'multipart/related; boundary=d41d8cd98f00b204e9800998ecf8427e; type=application/alto-endpointcost+json; charset=utf-8'},
         'text': TEST_ECS_PV,
+        'status_code': 200
+    },
+    {
+        'uri': 'http://localhost:8000/endpointcost/lookup',
+        'headers': {'content-type': "application/json"},
+        'json': TEST_VISUALNET_API_ECS,
         'status_code': 200
     }
 ]

--- a/src/alto/server/components/backend.py
+++ b/src/alto/server/components/backend.py
@@ -210,9 +210,13 @@ class GeoDistanceService(GeoIPPropertyService):
                                                math.cos(lat1)*math.cos(lat2)*math.sin(d_lng/2)**2))
         return d_geo
 
-    def lookup(self, srcs, dsts):
+    def lookup(self, srcs, dsts, cost_type):
         if self.autoreload:
             self.db.build_cache()
+
+        content = dict()
+        content['meta'] = dict()
+        content['meta']['cost-type'] = cost_type
 
         costs = dict()
         endpoints = set(srcs).union(set(dsts))
@@ -227,7 +231,8 @@ class GeoDistanceService(GeoIPPropertyService):
                 if not dst_loc:
                     continue
                 costs[s][d] = self.get_geo_distance(src_loc, dst_loc)
-        return costs
+        content['endpoint-cost-map'] = costs
+        return content
 
 
 class PathVectorService:

--- a/src/alto/server/components/backend.py
+++ b/src/alto/server/components/backend.py
@@ -42,7 +42,6 @@ from alto.mock import (TEST_DYNAMIC_NM_1,
                        TEST_DYNAMIC_NM_5)
 
 from .db import data_broker_manager
-from .vcs import vcs_singleton
 
 
 class MockService:
@@ -360,6 +359,8 @@ class TIPSControlService:
     """
 
     def __init__(self, namespace, tips_resource_id='', **kwargs) -> None:
+        from .vcs import vcs_singleton
+
         self.ns = namespace
         self.vcs = vcs_singleton
         self.tips_resource_id = tips_resource_id

--- a/src/alto/server/components/ext/perfsonar.py
+++ b/src/alto/server/components/ext/perfsonar.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# The MIT License (MIT)
+#
+# Copyright (c) 2023 OpenALTO Community
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Authors:
+# - Kai Gao <emiapwil@gmail.com>
+
+import requests
+
+from alto.config import Config
+
+class WrappedPerfSonarServiceV1:
+    """
+    Backend algorithm for ECS based on PerfSonar wrapper
+
+    This algorithm is basically a proxy
+    """
+
+    def __init__(self, uri, **kwargs):
+        self.uri = uri
+
+    def lookup(self, srcs, dsts, cost_type):
+        headers = {
+            'accept': 'application/json'
+        }
+        req = {
+            'cost-type': {
+                'cost-metric': cost_type['cost-metric'],
+                'anchor-alg': 'same-site',
+                'interval': { 'last': '2d' }
+            },
+            'endpoints': [
+                {
+                    'srcs': srcs,
+                    'dsts': dsts
+                }
+            ]
+        }
+        data = requests.post(self.uri, data=req, headers=headers)
+        print(data)
+        return None

--- a/src/alto/server/components/ext/perfsonar.py
+++ b/src/alto/server/components/ext/perfsonar.py
@@ -56,5 +56,5 @@ class WrappedPerfSonarServiceV1:
         }
         resp = requests.post(self.uri, json=req, headers=headers)
         data = resp.json()
-        data['cost-type']['cost-mode'] = cost_type['cost-mode']
+        data['meta']['cost-type']['cost-mode'] = cost_type['cost-mode']
         return data

--- a/src/alto/server/components/ext/perfsonar.py
+++ b/src/alto/server/components/ext/perfsonar.py
@@ -55,4 +55,6 @@ class WrappedPerfSonarServiceV1:
             ]
         }
         resp = requests.post(self.uri, json=req, headers=headers)
-        return resp.json()
+        data = resp.json()
+        data['cost-type']['cost-mode'] = cost_type['cost-mode']
+        return data

--- a/src/alto/server/components/ext/perfsonar.py
+++ b/src/alto/server/components/ext/perfsonar.py
@@ -33,9 +33,9 @@ class WrappedPerfSonarServiceV1:
     This algorithm is basically a proxy
     """
 
-    def __init__(self, namespace, uri=None, **kwargs):
+    def __init__(self, namespace, visualnet_api=None, **kwargs):
         self.namespace = namespace
-        self.uri = uri
+        self.uri = visualnet_api
 
     def lookup(self, srcs, dsts, cost_type):
         headers = {

--- a/src/alto/server/components/ext/perfsonar.py
+++ b/src/alto/server/components/ext/perfsonar.py
@@ -26,8 +26,6 @@
 
 import requests
 
-from alto.config import Config
-
 class WrappedPerfSonarServiceV1:
     """
     Backend algorithm for ECS based on PerfSonar wrapper
@@ -35,12 +33,13 @@ class WrappedPerfSonarServiceV1:
     This algorithm is basically a proxy
     """
 
-    def __init__(self, uri, **kwargs):
+    def __init__(self, namespace, uri=None, **kwargs):
+        self.namespace = namespace
         self.uri = uri
 
     def lookup(self, srcs, dsts, cost_type):
         headers = {
-            'accept': 'application/json'
+            'content-type': 'application/json'
         }
         req = {
             'cost-type': {
@@ -55,6 +54,5 @@ class WrappedPerfSonarServiceV1:
                 }
             ]
         }
-        data = requests.post(self.uri, data=req, headers=headers)
-        print(data)
-        return None
+        resp = requests.post(self.uri, json=req, headers=headers)
+        return resp.json()

--- a/src/alto/server/northbound/alto/render.py
+++ b/src/alto/server/northbound/alto/render.py
@@ -64,7 +64,8 @@ class EndpointCostRender(JSONRenderer):
 
     def render(self, ecmap, accepted_media_type=None, renderer_context=None):
         data = dict()
-        data['endpoint-cost-map'] = ecmap
+        data['meta'] = ecmap['meta']
+        data['endpoint-cost-map'] = ecmap['endpoint-cost-map']
         return super(EndpointCostRender, self).render(data, accepted_media_type,
                                                       renderer_context)
 

--- a/src/alto/server/northbound/alto/views.py
+++ b/src/alto/server/northbound/alto/views.py
@@ -289,7 +289,7 @@ class TIPSView(APIView):
     renderer_classes = [TIPSRender]
     parser_classes = [TIPSParser]
 
-    algorithm = TIPSControlService(config.get_default_namespace())
+    algorithm = None # TIPSControlService(config.get_default_namespace())
     resource_id = ''
     content_type = ALTO_CONTENT_TYPE_TIPS
 
@@ -310,7 +310,7 @@ class TIPSMetadataView(APIView):
     """
     renderer_classes = [TIPSRender]
 
-    algorithm = TIPSControlService(config.get_default_namespace())
+    algorithm = None # TIPSControlService(config.get_default_namespace())
     resource_id = ''
     content_type = ALTO_CONTENT_TYPE_TIPS_VIEW
 
@@ -336,7 +336,7 @@ class TIPSDataTransferView(APIView):
     """
     renderer_classes = [TIPSRender]
 
-    algorithm = TIPSControlService(config.get_default_namespace())
+    algorithm = None # TIPSControlService(config.get_default_namespace())
     resource_id = ''
     content_type = ALTO_CONTENT_TYPE_TIPS
 

--- a/src/alto/server/northbound/alto/views.py
+++ b/src/alto/server/northbound/alto/views.py
@@ -127,8 +127,8 @@ class EndpointCostView(APIView):
         dsts = endpoint_filter['dsts']
         cost_type = request.data.get('cost-type')
         if cost_type:
-            self.safe_check(cost_type) 
-        content = self.algorithm.lookup(srcs, dsts)
+            self.safe_check(cost_type)
+        content = self.algorithm.lookup(srcs, dsts, cost_type)
         constraints = request.data.get('constraints')
         if constraints:
             content = self.apply_constraints(content, constraints)


### PR DESCRIPTION
Implement a proxy to the visualnet API which is a thirdparty perfsonar-based ECS backend.

Example visualnet API: https://visualnet-api.nrp-nautilus.io/